### PR TITLE
Filter out non-AMD cards.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,16 +28,15 @@ impl FromStr for Card {
             .parse::<u32>()
             .map_err(|e| AmdFanError::InvalidSuffix(format!("{:?}", e)))
             .map(|n| Card(n))?;
-        match std::fs::read_to_string(format!("{}/{}/device/vendor", ROOT_DIR, card)) {
-            Ok(vendor) => {
+        std::fs::read_to_string(format!("{}/{}/device/vendor", ROOT_DIR, card))
+            .map_err(|_| AmdFanError::FailedReadVendor)
+            .and_then(|vendor| {
                 if vendor.trim() == "0x1002" {
                     Ok(card)
                 } else {
                     Err(AmdFanError::NotAmdCard)
                 }
-            }
-            Err(_) => Err(AmdFanError::FailedReadVendor),
-        }
+            })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ pub enum AmdFanError {
     InvalidPrefix,
     InputTooShort,
     InvalidSuffix(String),
+    NotAmdCard,
+    FailedReadVendor,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The current version allows other vendors' cards into the buffer that's then used to build up the controllers buffer. However, other vendors' cards aren't guaranteed to have the `hwmon` dir, which causes the `amdfand` executable to fail on my system, which has an Nvidia GTX 760 and AMD RX 480. You could also potentially move this vendor check elsewhere, but I chose to add it into creating `Card`s.